### PR TITLE
Php8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,17 @@
       "role": "Developer"
     }
   ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url":  "git@github.com:Lacni135/expose.git"
+    }
+  ],
   "license": "MIT",
   "require": {
     "php": ">=7.3",
     "pug-php/pug": "2.*",
-    "enygma/expose": "^3.0",
+    "enygma/expose": "dev-php8.1-compatibility",
     "ext-pdo": "*",
     "ext-json": "*",
     "ext-simplexml": "*",
@@ -24,7 +30,6 @@
     "ext-openssl": "*"
   },
   "require-dev": {
-    "php": ">=7.3",
     "phpunit/phpunit": "9.*.*",
     "ext-xdebug": "*"
   },

--- a/src/Zephyrus/Application/ViewBuilder.php
+++ b/src/Zephyrus/Application/ViewBuilder.php
@@ -58,10 +58,11 @@ class ViewBuilder
     {
         $cacheEnabled = Configuration::getConfiguration('pug', 'cache_enabled');
         $cacheDirectory = Configuration::getConfiguration('pug', 'cache_directory');
+        $upToDateCheck = Configuration::getConfiguration('pug', 'up_to_date_check', true);
         $options = [
             'basedir' => realpath(ROOT_DIR . '/public'),
             'expressionLanguage' => 'js',
-            'upToDateCheck' => true,
+            'upToDateCheck' => $upToDateCheck,
             'cache' => $cacheEnabled ? $cacheDirectory : null
         ];
         $this->pug = new Pug($options);

--- a/src/Zephyrus/Application/ViewBuilder.php
+++ b/src/Zephyrus/Application/ViewBuilder.php
@@ -44,6 +44,16 @@ class ViewBuilder
         $this->pug->share([$name => $action]);
     }
 
+    public function generateCache(): array
+    {
+        $cacheDirectory = Configuration::getConfiguration('pug', 'cache_directory');
+        $cacheEnabled = Configuration::getConfiguration('pug', 'cache_enabled');
+        if (!$cacheEnabled) {
+            throw new \InvalidArgumentException("The cache_enabled property has not been enabled in the configuration file");
+        }
+        return $this->pug->cacheDirectory($cacheDirectory);
+    }
+
     private function buildPug()
     {
         $cacheEnabled = Configuration::getConfiguration('pug', 'cache_enabled');

--- a/src/Zephyrus/Database/Core/TransactionPDO.php
+++ b/src/Zephyrus/Database/Core/TransactionPDO.php
@@ -13,7 +13,7 @@ class TransactionPDO extends \PDO
      * PDO begin transaction override to work with savepoint capabilities for
      * supported SGBD. Allows nested transactions.
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         if ($this->currentTransactionLevel == 0 || !$this->nestable()) {
             parent::beginTransaction();
@@ -28,13 +28,13 @@ class TransactionPDO extends \PDO
      * PDO commit override to work with savepoint capabilities for supported
      * SGBD. Allows nested transactions.
      */
-    public function commit()
+    public function commit(): bool
     {
         --$this->currentTransactionLevel;
         if ($this->currentTransactionLevel == 0 || !$this->nestable()) {
-            parent::commit();
+            return parent::commit();
         } else {
-            $this->exec("RELEASE SAVEPOINT LEVEL{$this->currentTransactionLevel}");
+            return $this->exec("RELEASE SAVEPOINT LEVEL{$this->currentTransactionLevel}");
         }
     }
 
@@ -42,13 +42,13 @@ class TransactionPDO extends \PDO
      * PDO rollback override to work with savepoint capabilities for
      * supported SGBD. Allows nested transactions.
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         --$this->currentTransactionLevel;
         if ($this->currentTransactionLevel == 0 || !$this->nestable()) {
-            parent::rollBack();
+            return parent::rollBack();
         } else {
-            $this->exec("ROLLBACK TO SAVEPOINT LEVEL{$this->currentTransactionLevel}");
+            return $this->exec("ROLLBACK TO SAVEPOINT LEVEL{$this->currentTransactionLevel}");
         }
     }
 

--- a/src/Zephyrus/Utilities/Formatters/TimeFormatter.php
+++ b/src/Zephyrus/Utilities/Formatters/TimeFormatter.php
@@ -1,6 +1,8 @@
 <?php namespace Zephyrus\Utilities\Formatters;
 
 use DateTime;
+use IntlDateFormatter;
+use Locale;
 use Zephyrus\Application\Configuration;
 
 trait TimeFormatter
@@ -10,7 +12,9 @@ trait TimeFormatter
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
-        return strftime(Configuration::getConfiguration('lang', 'date'), $dateTime->getTimestamp());
+        $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::LONG, IntlDateFormatter::NONE, null, null, "d LLLL yyyy");
+        return $formatter->format($dateTime->getTimestamp());
+        //return strftime(Configuration::getConfiguration('lang', 'date'), $dateTime->getTimestamp());
     }
 
     public static function datetime($dateTime)
@@ -18,7 +22,11 @@ trait TimeFormatter
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
-        return strftime(Configuration::getConfiguration('lang', 'datetime'), $dateTime->getTimestamp());
+        //1 janvier 2016, 23:15
+        $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::LONG, IntlDateFormatter::SHORT, null, null, " d LLLL yyyy, H:mm");
+        return $formatter->format($dateTime->getTimestamp());
+
+        //return strftime(Configuration::getConfiguration('lang', 'datetime'), $dateTime->getTimestamp());
     }
 
     public static function time($dateTime)
@@ -26,7 +34,10 @@ trait TimeFormatter
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
-        return strftime(Configuration::getConfiguration('lang', 'time'), $dateTime->getTimestamp());
+        $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::NONE, IntlDateFormatter::LONG, null, null, "H:mm");
+        return $formatter->format($dateTime->getTimestamp());
+
+        //return strftime(Configuration::getConfiguration('lang', 'time'), $dateTime->getTimestamp());
     }
 
     public static function duration($seconds, $minuteSuffix = ":", $hourSuffix = ":", $secondSuffix = "")

--- a/src/Zephyrus/Utilities/ListView.php
+++ b/src/Zephyrus/Utilities/ListView.php
@@ -60,10 +60,10 @@ class ListView
     /**
      * Highlights matching search into the given data string.
      *
-     * @param string|null $data
+     * @param string $data
      * @return string
      */
-    public function mark(?string $data): string
+    public function mark(string $data): string
     {
         if (empty($data)) {
             return "";

--- a/src/Zephyrus/Utilities/Pager.php
+++ b/src/Zephyrus/Utilities/Pager.php
@@ -52,7 +52,7 @@ class Pager
         $this->currentPage = (!is_numeric($page) || $page < 0) ? 1 : $page;
         $this->maxPage = ceil($recordCount / $maxEntities);
         $this->pageUrl = $request->getUri()->getPath();
-        $this->pageQuery = $this->getQueryString($request->getUri()->getQuery());
+        $this->pageQuery = $this->getQueryString($request->getUri()->getQuery() ?? "");
         $this->offset = $this->maxEntities * ($this->currentPage - 1);
         $this->validate();
     }

--- a/tests/application/FormatterTest.php
+++ b/tests/application/FormatterTest.php
@@ -87,7 +87,7 @@ class FormatterTest extends TestCase
     public function testFormatDate()
     {
         $result = Formatter::date('2016-01-01 23:15:00');
-        self::assertEquals(' 1 janvier 2016', $result);
+        self::assertEquals('1 janvier 2016', $result);
     }
 
     public function testFormatDateTime()

--- a/tests/utilities/ListViewTest.php
+++ b/tests/utilities/ListViewTest.php
@@ -59,8 +59,8 @@ class ListViewTest extends TestCase
     public function testMarkGuard()
     {
         $list = $this->buildList();
-        // safety guard if the value is null wont provoke error
-        self::assertEquals('', $list->mark(null));
+        // safety guard if the value is empty won't provoke error
+        self::assertEquals('', $list->mark(""));
     }
 
     public function testAdditionalData()


### PR DESCRIPTION
Multiple commit to remove deprecated stuff from php8.1
-  date/time format are now hardcoded to prevent breaking previous format specified inside config.ini. When ready to make the change, take the format inside the new class and paste inside config.ini