### PR TITLE
Replaced deprecated strftime() for IntlDateFormatter class

### DIFF
--- a/src/Zephyrus/Utilities/Formatters/TimeFormatter.php
+++ b/src/Zephyrus/Utilities/Formatters/TimeFormatter.php
@@ -1,6 +1,8 @@
 <?php namespace Zephyrus\Utilities\Formatters;
 
 use DateTime;
+use IntlDateFormatter;
+use Locale;
 use Zephyrus\Application\Configuration;
 
 trait TimeFormatter
@@ -10,7 +12,8 @@ trait TimeFormatter
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
-        return strftime(Configuration::getConfiguration('lang', 'date'), $dateTime->getTimestamp());
+        $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::LONG, IntlDateFormatter::NONE, null, null, Configuration::getConfiguration('lang', 'date', "d LLLL yyyy"));
+        return $formatter->format($dateTime->getTimestamp());
     }
 
     public static function datetime($dateTime)
@@ -18,7 +21,8 @@ trait TimeFormatter
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
-        return strftime(Configuration::getConfiguration('lang', 'datetime'), $dateTime->getTimestamp());
+        $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::LONG, IntlDateFormatter::SHORT, null, null, Configuration::getConfiguration('lang', 'datetime', " d LLLL yyyy, H:mm"));
+        return $formatter->format($dateTime->getTimestamp());
     }
 
     public static function time($dateTime)
@@ -26,7 +30,8 @@ trait TimeFormatter
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
-        return strftime(Configuration::getConfiguration('lang', 'time'), $dateTime->getTimestamp());
+        $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::NONE, IntlDateFormatter::LONG, null, null, Configuration::getConfiguration('lang', 'time', "H:mm"));
+        return $formatter->format($dateTime->getTimestamp());
     }
 
     public static function duration($seconds, $minuteSuffix = ":", $hourSuffix = ":", $secondSuffix = "")

--- a/tests/Application/FormatterTest.php
+++ b/tests/Application/FormatterTest.php
@@ -87,13 +87,13 @@ class FormatterTest extends TestCase
     public function testFormatDate()
     {
         $result = Formatter::date('2016-01-01 23:15:00');
-        self::assertEquals(' 1 janvier 2016', $result);
+        self::assertEquals('1 janvier 2016', $result);
     }
 
     public function testFormatDateTime()
     {
         $result = Formatter::datetime('2016-01-01 23:15:00');
-        self::assertEquals(' 1 janvier 2016, 23:15', $result);
+        self::assertEquals('1 janvier 2016, 23:15', $result);
     }
 
     public function testFormatSizeKb()

--- a/tests/config.ini
+++ b/tests/config.ini
@@ -40,9 +40,9 @@ exceptions[] = __utmz
 exceptions[] = __utmc
 
 [lang]
-date = "%e %B %Y"
-time = "%H:%M"
-datetime = "%e %B %Y, %H:%M"
+date = "d LLLL yyyy"
+time = "H:mm"
+datetime = "d LLLL yyyy, H:mm"
 
 [pug]
 cache_enabled = false


### PR DESCRIPTION
**CAREFUL THIS PR IS BREAKING THE CURRENT CONFIG.INI IMPLEMENTATION**

This pull request aims to replace the deprecated function `strftime()` for the more robust and complete `IntlDateFormatter` class from the `Intl` extension.

https://php.watch/versions/8.1/strftime-gmstrftime-deprecated
https://wiki.php.net/rfc/deprecations_php_8_1#strftime_and_gmstrftime

The new format follows the ICU ([Unicode](https://icu.unicode.org/)) standard which can be found here:
https://unicode-org.github.io/icu/userguide/format_parse/datetime/