### PR TITLE
Refactor TimeFormatter Trait to handle null values

### DIFF
--- a/src/Zephyrus/Utilities/Formatters/TimeFormatter.php
+++ b/src/Zephyrus/Utilities/Formatters/TimeFormatter.php
@@ -7,31 +7,43 @@ use Zephyrus\Application\Configuration;
 
 trait TimeFormatter
 {
-    public static function date($dateTime)
+    public static function date(DateTime|string|null $dateTime): string
     {
+        if (is_null($dateTime)) {
+            return "-";
+        }
+
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
         $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::LONG, IntlDateFormatter::NONE, null, null, Configuration::getConfiguration('lang', 'date', "d LLLL yyyy"));
-        return $formatter->format($dateTime->getTimestamp());
+        return $formatter->format($dateTime->getTimestamp()) ?: "-";
     }
 
-    public static function datetime($dateTime)
+    public static function datetime(DateTime|string|null $dateTime): string
     {
+        if (is_null($dateTime)) {
+            return "-";
+        }
+
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
         $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::LONG, IntlDateFormatter::SHORT, null, null, Configuration::getConfiguration('lang', 'datetime', "d LLLL yyyy, HH:mm"));
-        return $formatter->format($dateTime->getTimestamp());
+        return $formatter->format($dateTime->getTimestamp()) ?: "-";
     }
 
-    public static function time($dateTime)
+    public static function time(DateTime|string|null $dateTime): string
     {
+        if (is_null($dateTime)) {
+            return "-";
+        }
+
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new DateTime($dateTime);
         }
         $formatter = new IntlDateFormatter(Locale::getDefault(), IntlDateFormatter::NONE, IntlDateFormatter::LONG, null, null, Configuration::getConfiguration('lang', 'time', "HH:mm"));
-        return $formatter->format($dateTime->getTimestamp());
+        return $formatter->format($dateTime->getTimestamp()) ?: "-";
     }
 
     public static function duration($seconds, $minuteSuffix = ":", $hourSuffix = ":", $secondSuffix = "")

--- a/tests/Application/FormatterTest.php
+++ b/tests/Application/FormatterTest.php
@@ -82,12 +82,18 @@ class FormatterTest extends TestCase
     {
         $result = Formatter::time('2016-01-01 23:15:00');
         self::assertEquals('23:15', $result);
+
+        $result = Formatter::time(null);
+        self::assertEquals('-', $result);
     }
 
     public function testFormatDate()
     {
         $result = Formatter::date('2016-01-01 23:15:00');
         self::assertEquals('1 janvier 2016', $result);
+
+        $result = Formatter::date(null);
+        self::assertEquals('-', $result);
     }
 
     public function testFormatDateTime()
@@ -97,6 +103,9 @@ class FormatterTest extends TestCase
 
         $result = Formatter::datetime('2016-01-01 01:15:00');
         self::assertEquals('1 janvier 2016, 01:15', $result);
+
+        $result = Formatter::datetime(null);
+        self::assertEquals('-', $result);
     }
 
     public function testFormatSizeKb()


### PR DESCRIPTION
With php8.1, DateTime() no longer accepts a null value as a parameter. Previously, a null value would return the current timestamp (now). Since null is no longer accepted, we refactor to return "-" when the value is null.
This also ensure backward compatibility.