### PR TITLE
Changed router behaviour to add a priority for hardcoded routes.

### DIFF
--- a/src/Zephyrus/Network/Router.php
+++ b/src/Zephyrus/Network/Router.php
@@ -188,6 +188,11 @@ class Router
         if (empty($matchingRoutes)) {
             throw new RouteNotFoundException($this->requestedUri, $this->requestedMethod);
         }
+
+        usort($matchingRoutes, function ($a, $b) {
+            return strcmp($a->route->getUri(), $b->route->getUri());
+        });
+
         foreach ($matchingRoutes as $routeDefinition) {
             if ($this->isRequestAcceptedForRoute($routeDefinition)) {
                 return $routeDefinition;

--- a/tests/Network/RouterTest.php
+++ b/tests/Network/RouterTest.php
@@ -225,4 +225,28 @@ class RouterTest extends TestCase
         });
         $router->run($req);
     }
+
+    public function testRouteConflictOrder()
+    {
+        $req = new Request('http://test.local/test/test', 'GET');
+        $router = new Router();
+
+        $router->get('/test/{id}', function($id) {
+            $response = new Response();
+            $response->setContent('test1');
+            return $response;
+
+        });
+        $router->get('/test/test', function() {
+            $response = new Response();
+            $response->setContent('test2');
+            return $response;
+
+        });
+
+        ob_start();
+        $router->run($req);
+        $output = ob_get_clean();
+        self::assertEquals("test2", $output);
+    }
 }


### PR DESCRIPTION
With php8.1, DateTime() no longer accepts a null value as a parameter. Previously, a null value would return the current timestamp (now). Since null is no longer accepted, we refactor to return "-" when the value is null.
This also ensure backward compatibility.

Thanks to @wolflo256 for the `usort` method