### PR TITLE
More php8.1 deprecation

### DIFF
--- a/src/Zephyrus/Network/Responses/StreamResponses.php
+++ b/src/Zephyrus/Network/Responses/StreamResponses.php
@@ -102,7 +102,6 @@ trait StreamResponses
         header("Connection: keep-alive");
         set_time_limit(0);
         ignore_user_abort(true);
-        ini_set('auto_detect_line_endings', 1);
         ini_set('max_execution_time', '0');
         // @codeCoverageIgnoreStart
         // ob_get_level should always be at 1 when using SSE, this if is for

--- a/src/Zephyrus/Utilities/Formatters/NumericFormatter.php
+++ b/src/Zephyrus/Utilities/Formatters/NumericFormatter.php
@@ -4,36 +4,48 @@ use Zephyrus\Application\Configuration;
 
 trait NumericFormatter
 {
-    public static function percent($number, $minDecimals = 2, $maxDecimals = 4)
+    public static function percent(int|float|null $number, int $minDecimals = 2, int $maxDecimals = 4): string
     {
+        if (is_null($number)) {
+            return "-";
+        }
+
         $locale = Configuration::getApplicationConfiguration('locale');
         $formatter = new \NumberFormatter($locale, \NumberFormatter::PERCENT);
         $formatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, $maxDecimals);
         $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $minDecimals);
         $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, \NumberFormatter::ROUND_HALFUP);
-        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE);
+        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE) ?: "-";
         return $result;
     }
 
-    public static function money($amount, $minDecimals = 2, $maxDecimals = 2)
+    public static function money(int|float|null $amount, int $minDecimals = 2, int $maxDecimals = 2): string
     {
+        if (is_null($amount)) {
+            return "-";
+        }
+
         $locale = Configuration::getApplicationConfiguration('locale');
         $formatter = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
         $formatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, $maxDecimals);
         $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $minDecimals);
         $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, \NumberFormatter::ROUND_HALFUP);
-        $result = $formatter->formatCurrency($amount, Configuration::getApplicationConfiguration('currency'));
+        $result = $formatter->formatCurrency($amount, Configuration::getApplicationConfiguration('currency')) ?: "-";
         return $result;
     }
 
-    public static function decimal($number, $minDecimals = 2, $maxDecimals = 4)
+    public static function decimal(int|float|null $number, int $minDecimals = 2, int $maxDecimals = 4): string
     {
+        if (is_null($number)) {
+            return "-";
+        }
+
         $locale = Configuration::getApplicationConfiguration('locale');
         $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
         $formatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, $maxDecimals);
         $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $minDecimals);
         $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, \NumberFormatter::ROUND_HALFUP);
-        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE);
+        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE) ?: "-";
         return $result;
     }
 }

--- a/src/Zephyrus/Utilities/Formatters/SpecializedFormatter.php
+++ b/src/Zephyrus/Utilities/Formatters/SpecializedFormatter.php
@@ -11,7 +11,7 @@ trait SpecializedFormatter
      * @param string $name
      * @return string
      */
-    public static function seourl(string $name)
+    public static function seourl(string $name): string
     {
         $url = mb_strtolower($name);
         $url = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $url);
@@ -29,7 +29,8 @@ trait SpecializedFormatter
     public static function filesize(
         int $sizeInBytes,
         array $units = ['G' => 'gb', 'M' => 'mb', 'K' => 'kb', 'B' => 'bytes']
-    ) {
+    ): string
+    {
         $fileSize = $sizeInBytes;
         $unit = $units['B'];
         if ($sizeInBytes >= 1073741824) {
@@ -45,7 +46,7 @@ trait SpecializedFormatter
         return Formatter::decimal($fileSize, 0, 2) . ' ' . $unit;
     }
 
-    public static function ellipsis(string $str, int $length = 50, string $concat = "...")
+    public static function ellipsis(string $str, int $length = 50, string $concat = "..."): string
     {
         return (strlen($str) > $length) ? substr($str, 0, $length) . $concat : $str;
     }


### PR DESCRIPTION
Removed deprecated ini_set() of 'auto_detect_line_ending' for php8.1

We can safely remove this line since it only provides support for an old MacOS standard that has been removed in 2001 (2 decades ago)
https://wiki.php.net/rfc/deprecations_php_8_1#auto_detect_line_endings_ini_setting