### PR TITLE
Fixed formatting issue

### DIFF
--- a/src/Zephyrus/Utilities/Formatters/NumericFormatter.php
+++ b/src/Zephyrus/Utilities/Formatters/NumericFormatter.php
@@ -15,8 +15,8 @@ trait NumericFormatter
         $formatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, $maxDecimals);
         $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $minDecimals);
         $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, \NumberFormatter::ROUND_HALFUP);
-        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE) ?: "-";
-        return $result;
+        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE);
+        return $result === false ? "-" : $result;
     }
 
     public static function money(int|float|null $amount, int $minDecimals = 2, int $maxDecimals = 2): string
@@ -30,8 +30,8 @@ trait NumericFormatter
         $formatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, $maxDecimals);
         $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $minDecimals);
         $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, \NumberFormatter::ROUND_HALFUP);
-        $result = $formatter->formatCurrency($amount, Configuration::getApplicationConfiguration('currency')) ?: "-";
-        return $result;
+        $result = $formatter->formatCurrency($amount, Configuration::getApplicationConfiguration('currency'));
+        return $result === false ? "-" : $result;
     }
 
     public static function decimal(int|float|null $number, int $minDecimals = 2, int $maxDecimals = 4): string
@@ -45,7 +45,7 @@ trait NumericFormatter
         $formatter->setAttribute(\NumberFormatter::MAX_FRACTION_DIGITS, $maxDecimals);
         $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $minDecimals);
         $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, \NumberFormatter::ROUND_HALFUP);
-        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE) ?: "-";
-        return $result;
+        $result = $formatter->format($number, \NumberFormatter::TYPE_DOUBLE);
+        return $result === false ? "-" : $result;
     }
 }

--- a/tests/Application/FormatterTest.php
+++ b/tests/Application/FormatterTest.php
@@ -34,6 +34,8 @@ class FormatterTest extends TestCase
         self::assertEquals("12,2", $result);
         $result = Formatter::decimal(12, 0, 0);
         self::assertEquals("12", $result);
+        $result = Formatter::decimal(0, 0, 0);
+        self::assertEquals("0", $result);
     }
 
     public function testFormatSeoUrl()
@@ -66,6 +68,8 @@ class FormatterTest extends TestCase
         self::assertEquals('2,27 $', $result);
         $result = Formatter::money(2.263);
         self::assertEquals('2,26 $', $result);
+        $result = Formatter::money(0);
+        self::assertEquals('0,00 $', $result);
     }
 
     public function testFormatPercent()


### PR DESCRIPTION
Fixed a format issue when "0" was passed explicitly to the formatter. Only "null" should format to "-" and explicit "0" should format to "0".
Also added a test case for this specific occurrence.