### PR TITLE
fix: add is_null verification on data

### DIFF
--- a/src/Zephyrus/Utilities/Components/ListView.php
+++ b/src/Zephyrus/Utilities/Components/ListView.php
@@ -39,6 +39,9 @@ class ListView
     {
         $search = $this->filter?->getFunnel()->getSearch();
         if (is_null($search)) {
+            if (is_null($data)) {
+                return "";
+            }
             return $data;
         }
         if (empty($data)) {


### PR DESCRIPTION
Added the is_null verification on $data if the search query is empty since the function can receive null values but cannot return null values.