### PR TITLE
fix: pager parsing parameter evaluation

### DIFF
--- a/src/Zephyrus/Utilities/Components/FilterConfiguration.php
+++ b/src/Zephyrus/Utilities/Components/FilterConfiguration.php
@@ -69,7 +69,7 @@ class FilterConfiguration
     private function parsePage(): ?int
     {
         $source = $this->request->getParameter($this->pageParameter);
-        if (!is_int($source)) {
+        if (!ctype_digit($source ?? "")) {
             return null;
         }
         return $source;
@@ -78,7 +78,7 @@ class FilterConfiguration
     private function parseLimit(): ?int
     {
         $source = $this->request->getParameter($this->limitParameter);
-        if (!is_int($source)) {
+        if (!ctype_digit($source ?? "")) {
             return null;
         }
         return $source;


### PR DESCRIPTION
Unable to change list page because of is_int evaluating page parameter always as string.