### PR TITLE
Fix: Les flash et feedback ne marche pas

### DIFF
--- a/src/Zephyrus/Application/Feedback.php
+++ b/src/Zephyrus/Application/Feedback.php
@@ -11,7 +11,7 @@ class Feedback
     {
         $feedback = Session::getInstance()->read('__FEEDBACK');
         $args = [];
-        $args["feedback"]["error"] = $feedback['ERROR'] ?? [];
+        $args["error"] = $feedback['ERROR'] ?? [];
         self::clearAll();
         return $args;
     }

--- a/src/Zephyrus/Application/Flash.php
+++ b/src/Zephyrus/Application/Flash.php
@@ -31,11 +31,11 @@ class Flash
     {
         $flash = Session::getInstance()->read('__FLASH');
         $args = [];
-        $args["flash"]["success"] = $flash['SUCCESS'] ?? "";
-        $args["flash"]["warning"] = $flash['WARNING'] ?? "";
-        $args["flash"]["error"] = $flash['ERROR'] ?? "";
-        $args["flash"]["notice"] = $flash['NOTICE'] ?? "";
-        $args["flash"]["info"] = $flash['INFO'] ?? "";
+        $args["success"] = $flash['SUCCESS'] ?? "";
+        $args["warning"] = $flash['WARNING'] ?? "";
+        $args["error"] = $flash['ERROR'] ?? "";
+        $args["notice"] = $flash['NOTICE'] ?? "";
+        $args["info"] = $flash['INFO'] ?? "";
         self::clearAll();
         return $args;
     }

--- a/src/Zephyrus/Application/Views/PugView.php
+++ b/src/Zephyrus/Application/Views/PugView.php
@@ -49,8 +49,8 @@ class PugView extends View
         $this->initializeJsExtension();
         Phug::setOption('paths', [realpath(ROOT_DIR . '/public')]);
         Phug::share([
-            Flash::readAll(),
-            Feedback::readAll()
+            ["flash" => Flash::readAll()],
+            ["feedback" => Feedback::readAll()]
         ]);
     }
 


### PR DESCRIPTION
**Que cela fix t-il?**

Fix les feedback et flash qui ne s'affichait pas dans le pug, du au fait qu'il était storer dans un index au lieux d'une clée. Voici le comportement actuel:

![image](https://user-images.githubusercontent.com/11786952/234883352-c6521cdb-614f-421b-937e-327216f0251e.png)

**Comment cela a été fixé?**

Changer les arguments dans les ReadAll des Flash et Feedback pour que se soit des array simple au lieux d'array à 2 dimensions et changé ce qui est envoyer dans le Phug::share pour des KeyValue au lieux d'être juste l'array retourner par les fonctions. Cela permet aussi de faire marcher les Flash et Feedback de marcher comme avant au lieux de faire `flash.flash['error']` dans les mixins par exemple.

**Résultat Attendu**

![image](https://user-images.githubusercontent.com/11786952/234883484-ba4bbb67-7f42-4ac9-b4db-8cccc9c0a243.png)



